### PR TITLE
Add Positional Data to the Lexer

### DIFF
--- a/lib/src/lexer/lexer_test.rs
+++ b/lib/src/lexer/lexer_test.rs
@@ -1,15 +1,15 @@
 use super::*;
-use crate::token::Token;
+use crate::token::TokenType;
 // Currently preferring many smaller tests over one giant one for a couple of reasons
 // - More readable
 // - Each test has an actual purpose
 // - It's easier to tell where a bug may be
-fn test_tokens(input: &str, tests: Vec<Token>) {
+fn test_tokens(input: &str, tests: Vec<TokenType>) {
     let mut l = Lexer::new(input);
     for test in tests {
         let tok = l.next_token();
         println!("{:?}", tok);
-        assert_eq!(tok, test);
+        assert_eq!(tok.tok, test);
     }
 }
 
@@ -17,9 +17,9 @@ fn test_tokens(input: &str, tests: Vec<Token>) {
 fn test_symbols() {
     let input = ":true + :false";
     let tests = vec![
-        Token::Symbol(String::from("true")),
-        Token::Plus,
-        Token::Symbol(String::from("false")),
+        TokenType::Symbol(String::from("true")),
+        TokenType::Plus,
+        TokenType::Symbol(String::from("false")),
     ];
     test_tokens(input, tests);
 }
@@ -28,20 +28,20 @@ fn test_symbols() {
 fn test_two_chars() {
     let input = "a != b == c >= d <= e :: 0..5 ->";
     let tests = vec![
-        Token::Ident(String::from("a")),
-        Token::NotEq,
-        Token::Ident(String::from("b")),
-        Token::Eq,
-        Token::Ident(String::from("c")),
-        Token::GreaterEq,
-        Token::Ident(String::from("d")),
-        Token::LessEq,
-        Token::Ident(String::from("e")),
-        Token::Match,
-        Token::Number(String::from("0")),
-        Token::Range,
-        Token::Number(String::from("5")),
-        Token::Arrow,
+        TokenType::Ident(String::from("a")),
+        TokenType::NotEq,
+        TokenType::Ident(String::from("b")),
+        TokenType::Eq,
+        TokenType::Ident(String::from("c")),
+        TokenType::GreaterEq,
+        TokenType::Ident(String::from("d")),
+        TokenType::LessEq,
+        TokenType::Ident(String::from("e")),
+        TokenType::Match,
+        TokenType::Number(String::from("0")),
+        TokenType::Range,
+        TokenType::Number(String::from("5")),
+        TokenType::Arrow,
     ];
     test_tokens(input, tests);
 }
@@ -50,11 +50,11 @@ fn test_two_chars() {
 fn test_identifiers() {
     let input = "abc my_number5 foo bar foobar";
     let tests = vec![
-        Token::Ident(String::from("abc")),
-        Token::Ident(String::from("my_number5")),
-        Token::Ident(String::from("foo")),
-        Token::Ident(String::from("bar")),
-        Token::Ident(String::from("foobar")),
+        TokenType::Ident(String::from("abc")),
+        TokenType::Ident(String::from("my_number5")),
+        TokenType::Ident(String::from("foo")),
+        TokenType::Ident(String::from("bar")),
+        TokenType::Ident(String::from("foobar")),
     ];
     test_tokens(input, tests);
 }
@@ -63,9 +63,9 @@ fn test_identifiers() {
 fn test_strings() {
     let input = "'hello ' + \"world\"";
     let tests = vec![
-        Token::String(String::from("hello ")),
-        Token::Plus,
-        Token::String(String::from("world")),
+        TokenType::String(String::from("hello ")),
+        TokenType::Plus,
+        TokenType::String(String::from("world")),
     ];
     test_tokens(input, tests);
 }
@@ -74,10 +74,10 @@ fn test_strings() {
 fn test_keywords() {
     let input = "import stuff from 'the place'";
     let tests = vec![
-        Token::Import,
-        Token::Ident(String::from("stuff")),
-        Token::From,
-        Token::String(String::from("the place")),
+        TokenType::Import,
+        TokenType::Ident(String::from("stuff")),
+        TokenType::From,
+        TokenType::String(String::from("the place")),
     ];
     test_tokens(input, tests);
 }
@@ -86,11 +86,11 @@ fn test_keywords() {
 fn test_numbers() {
     let input = "5 + 4 * 8000";
     let tests = vec![
-        Token::Number(String::from("5")),
-        Token::Plus,
-        Token::Number(String::from("4")),
-        Token::Asterisk,
-        Token::Number(String::from("8000")),
+        TokenType::Number(String::from("5")),
+        TokenType::Plus,
+        TokenType::Number(String::from("4")),
+        TokenType::Asterisk,
+        TokenType::Number(String::from("8000")),
     ];
     test_tokens(input, tests);
 }
@@ -99,20 +99,20 @@ fn test_numbers() {
 fn test_single() {
     let input = "=+-*/%(){},;:";
     let tests = vec![
-        Token::Assign,
-        Token::Plus,
-        Token::Minus,
-        Token::Asterisk,
-        Token::Slash,
-        Token::Modulus,
-        Token::LeftParen,
-        Token::RightParen,
-        Token::LeftBrace,
-        Token::RightBrace,
-        Token::Comma,
-        Token::Semicolon,
-        Token::Colon,
-        Token::EOF,
+        TokenType::Assign,
+        TokenType::Plus,
+        TokenType::Minus,
+        TokenType::Asterisk,
+        TokenType::Slash,
+        TokenType::Modulus,
+        TokenType::LeftParen,
+        TokenType::RightParen,
+        TokenType::LeftBrace,
+        TokenType::RightBrace,
+        TokenType::Comma,
+        TokenType::Semicolon,
+        TokenType::Colon,
+        TokenType::EOF,
     ];
     test_tokens(input, tests);
 }

--- a/lib/src/lexer/mod.rs
+++ b/lib/src/lexer/mod.rs
@@ -2,7 +2,7 @@ use std::iter::{Peekable, Enumerate};
 use std::str::Chars;
 
 use crate::token;
-use token::Token;
+use token::{Token, TokenType};
 
 #[cfg(test)]
 #[path = "./lexer_test.rs"]
@@ -40,7 +40,7 @@ impl<'a> Lexer<'a> {
         !self.peek_is(expected)
     }
 
-    fn two_char(&mut self, expected: char, single: Token, double: Token) -> Token {
+    fn two_char(&mut self, expected: char, single: TokenType, double: TokenType) -> TokenType {
         if self.peek_is(expected) {
             self.read();
             return double;
@@ -48,78 +48,84 @@ impl<'a> Lexer<'a> {
         single
     }
 
-    fn generate_token(&mut self, ch: char) -> Token {
+    fn generate_token(&mut self, ch: char) -> TokenType {
         match ch {
             // Symbols and Operators
-            '=' => self.two_char('=', Token::Assign, Token::Eq),
-            '+' => Token::Plus,
-            '-' => self.two_char('>', Token::Minus, Token::Arrow),
-            '*' => Token::Asterisk,
-            '%' => Token::Modulus,
-            '/' => Token::Slash,
+            '=' => self.two_char('=', TokenType::Assign, TokenType::Eq),
+            '+' => TokenType::Plus,
+            '-' => self.two_char('>', TokenType::Minus, TokenType::Arrow),
+            '*' => TokenType::Asterisk,
+            '%' => TokenType::Modulus,
+            '/' => TokenType::Slash,
             /*
             There are some complications with leading zero support though
             - It's potentially ambiguous (example ident.5)
             - We can't take things like this into context until parsing, so it might be better to handle this there (especially since that's also where we convert numbers to actual numbers)
              */
-            '.' => self.two_char('.', Token::Period, Token::Range),
+            '.' => self.two_char('.', TokenType::Period, TokenType::Range),
             // Equality Operators
-            '>' => self.two_char('=', Token::Greater, Token::GreaterEq),
-            '<' => self.two_char('=', Token::Less, Token::LessEq),
-            '!' => self.two_char('=', Token::Bang, Token::NotEq),
+            '>' => self.two_char('=', TokenType::Greater, TokenType::GreaterEq),
+            '<' => self.two_char('=', TokenType::Less, TokenType::LessEq),
+            '!' => self.two_char('=', TokenType::Bang, TokenType::NotEq),
 
             // Logical operators
-            '|' => self.two_char('|', Token::Illegal, Token::Or),
-            '&' => self.two_char('&', Token::Illegal, Token::And),
+            '|' => self.two_char('|', TokenType::Illegal, TokenType::Or),
+            '&' => self.two_char('&', TokenType::Illegal, TokenType::And),
 
             // Delimiters
-            ',' => Token::Comma,
-            ';' => Token::Semicolon,
+            ',' => TokenType::Comma,
+            ';' => TokenType::Semicolon,
             ':' => {
                 if let Some(&(_, next)) = self.peek() {
                     if Self::is_letter(next) {
                         self.read();
                         let text = self.read_identifier(next);
-                        return Token::Symbol(text);
+                        return TokenType::Symbol(text);
                     }
                 }
-                self.two_char(':', Token::Colon, Token::Match)
+                self.two_char(':', TokenType::Colon, TokenType::Match)
             }
 
             // Strings
             '\'' | '"' => {
                 let string = self.read_string(ch);
-                Token::String(string)
+                TokenType::String(string)
             }
 
             // Braces 'n stuff
-            '(' => Token::LeftParen,
-            ')' => Token::RightParen,
-            '{' => Token::LeftBrace,
-            '}' => Token::RightBrace,
-            '[' => Token::LeftBracket,
-            ']' => Token::RightBracket,
+            '(' => TokenType::LeftParen,
+            ')' => TokenType::RightParen,
+            '{' => TokenType::LeftBrace,
+            '}' => TokenType::RightBrace,
+            '[' => TokenType::LeftBracket,
+            ']' => TokenType::RightBracket,
             _ => {
                 if Self::is_letter(ch) {
                     let ident = self.read_identifier(ch);
                     return token::lookup_keyword(ident.as_str());
                 } else if Self::is_digit(ch) {
                     let number = self.read_number(ch);
-                    return Token::Number(number);
+                    return TokenType::Number(number);
                 }
-                Token::Illegal
+                TokenType::Illegal
             }
         }
     }
 
     pub fn next_token(&mut self) -> Token {
         self.skip_whitespace();
-        if let Some((_, ch)) = self.read() {
+        if let Some((offset, ch)) = self.read() {
             // Light abstraction to make this less ugly
             let tok = self.generate_token(ch);
-            return tok;
+            return Token {
+                tok,
+                offset
+            };
         }
-        Token::EOF
+        Token {
+            tok: TokenType::EOF,
+            offset: 0
+        }
     }
 
     // "is" functions

--- a/lib/src/lexer/mod.rs
+++ b/lib/src/lexer/mod.rs
@@ -1,4 +1,4 @@
-use std::iter::{Peekable, Enumerate};
+use std::iter::{Enumerate, Peekable};
 use std::str::Chars;
 
 use crate::token;
@@ -117,14 +117,11 @@ impl<'a> Lexer<'a> {
         if let Some((offset, ch)) = self.read() {
             // Light abstraction to make this less ugly
             let tok = self.generate_token(ch);
-            return Token {
-                tok,
-                offset
-            };
+            return Token { tok, offset };
         }
         Token {
             tok: TokenType::EOF,
-            offset: 0
+            offset: 0,
         }
     }
 

--- a/lib/src/parser/error.rs
+++ b/lib/src/parser/error.rs
@@ -1,4 +1,4 @@
-use crate::{style::emphasize, token::Token};
+use crate::{style::emphasize, token::TokenType};
 
 use crate::style::{bold, yellow};
 
@@ -24,13 +24,13 @@ pub enum ParserType {
     Hash,
 }
 pub enum ParserError<'a> {
-    ExpectedFound(&'a Token, &'a Token),
+    ExpectedFound(&'a TokenType, &'a TokenType),
     // NoPrefixFound(&'a Token),
 }
 
 fn assign_msg(err: ParserError) -> String {
     match err {
-    ParserError::ExpectedFound(&Token::Assign, got) => {
+    ParserError::ExpectedFound(&TokenType::Assign, got) => {
       return format!("When parsing an assignment statement, we were looking a {}, but we found something else ({:?}). There's a good change you forgot to put an equals sign, or put another token before it.", bold(&yellow("=")), got)
     },
     // The wildcard is safe here because this is the only expect_peek
@@ -40,7 +40,7 @@ fn assign_msg(err: ParserError) -> String {
 
 fn array_msg(err: ParserError) -> String {
     match err {
-        ParserError::ExpectedFound(&Token::RightBracket, got) => {
+        ParserError::ExpectedFound(&TokenType::RightBracket, got) => {
             let got = format!("{}", got);
             format!("When parsing an array, we were looking for right bracket {}, but we found something else ({}).
     
@@ -52,7 +52,7 @@ Hint: Double check to make sure you've closed all your arrays, and you should be
 
 fn match_msg(err: ParserError) -> String {
     match err {
-    ParserError::ExpectedFound(&Token::LeftBrace, got) => format!("When parsing a match expression, we were looking for a left brace {}, but we found something else ({}).
+    ParserError::ExpectedFound(&TokenType::LeftBrace, got) => format!("When parsing a match expression, we were looking for a left brace {}, but we found something else ({}).
 
  This most likely means that you accidentally used the match operator (::), or you just forgot a left bracket when opening the match", bold(&yellow("{")), got),
     _ => String::new()

--- a/lib/src/parser/error.rs
+++ b/lib/src/parser/error.rs
@@ -62,11 +62,38 @@ fn match_msg(err: ParserError) -> String {
   }
 }
 
-pub fn generate_parser_message(err: ParserError, t: ParserType) -> String {
-    match t {
+pub fn generate_parser_message(err: ParserError, t: ParserType, pos: Position, source: &str) -> String {
+    let mut msg = match t {
         ParserType::Assign => assign_msg(err),
         ParserType::Array => array_msg(err),
         ParserType::Match => match_msg(err),
         _ => String::new(),
+    };
+
+    msg.push('\n');
+
+    let error = generate_pretty_error(pos, source);
+
+    msg.push_str(&error);
+
+    msg
+}
+
+pub fn generate_pretty_error(pos: Position, source: &str) -> String {
+    let lines: Vec<&str> = source.split('\n').collect();
+    let line = lines[pos.line - 1];
+
+    let mut message = format!("{}. ", pos.line);
+
+    let offset = message.len();
+
+    message.push_str(line);
+
+    message.push('\n');
+    for _ in 1..pos.column + offset {
+        message.push(' ');
     }
+    message.push_str("^-- Here");
+
+    message
 }

--- a/lib/src/parser/error.rs
+++ b/lib/src/parser/error.rs
@@ -1,4 +1,4 @@
-use crate::{style::emphasize, token::TokenType};
+use crate::{style::emphasize, token::{Position, TokenType}};
 
 use crate::style::{bold, yellow};
 
@@ -24,14 +24,14 @@ pub enum ParserType {
     Hash,
 }
 pub enum ParserError<'a> {
-    ExpectedFound(&'a TokenType, &'a TokenType),
+    ExpectedFound(&'a TokenType, &'a TokenType, Position),
     // NoPrefixFound(&'a Token),
 }
 
 fn assign_msg(err: ParserError) -> String {
     match err {
-    ParserError::ExpectedFound(&TokenType::Assign, got) => {
-      return format!("When parsing an assignment statement, we were looking a {}, but we found something else ({:?}). There's a good change you forgot to put an equals sign, or put another token before it.", bold(&yellow("=")), got)
+    ParserError::ExpectedFound(&TokenType::Assign, got, position) => {
+      return format!("When parsing an assignment statement on line {}, column {}, we were looking a {}, but we found something else ({:?}). There's a good change you forgot to put an equals sign, or put another token before it.", position.line, position.column, bold(&yellow("=")), got)
     },
     // The wildcard is safe here because this is the only expect_peek
     _ => String::new()
@@ -40,11 +40,11 @@ fn assign_msg(err: ParserError) -> String {
 
 fn array_msg(err: ParserError) -> String {
     match err {
-        ParserError::ExpectedFound(&TokenType::RightBracket, got) => {
+        ParserError::ExpectedFound(&TokenType::RightBracket, got, position) => {
             let got = format!("{}", got);
-            format!("When parsing an array, we were looking for right bracket {}, but we found something else ({}).
+            format!("When parsing an array on line {}, column {}, we were looking for right bracket {}, but we found something else ({}).
     
-Hint: Double check to make sure you've closed all your arrays, and you should be on your way", emphasize("]"), emphasize(&got))
+Hint: Double check to make sure you've closed all your arrays, and you should be on your way", position.line, position.column,emphasize("]"), emphasize(&got))
         }
         _ => String::new(),
     }
@@ -52,9 +52,9 @@ Hint: Double check to make sure you've closed all your arrays, and you should be
 
 fn match_msg(err: ParserError) -> String {
     match err {
-    ParserError::ExpectedFound(&TokenType::LeftBrace, got) => format!("When parsing a match expression, we were looking for a left brace {}, but we found something else ({}).
+    ParserError::ExpectedFound(&TokenType::LeftBrace, got, position) => format!("When parsing a match expression on line {}, column {}, we were looking for a left brace {}, but we found something else ({}).
 
- This most likely means that you accidentally used the match operator (::), or you just forgot a left bracket when opening the match", bold(&yellow("{")), got),
+ This most likely means that you accidentally used the match operator (::), or you just forgot a left bracket when opening the match", position.line, position.column, bold(&yellow("{")), got),
     _ => String::new()
   }
 }

--- a/lib/src/parser/error.rs
+++ b/lib/src/parser/error.rs
@@ -62,7 +62,12 @@ fn match_msg(err: ParserError) -> String {
   }
 }
 
-pub fn generate_parser_message(err: ParserError, t: ParserType, pos: Position, source: &str) -> String {
+pub fn generate_parser_message(
+    err: ParserError,
+    t: ParserType,
+    pos: Position,
+    source: &str,
+) -> String {
     let mut msg = match t {
         ParserType::Assign => assign_msg(err),
         ParserType::Array => array_msg(err),

--- a/lib/src/parser/error.rs
+++ b/lib/src/parser/error.rs
@@ -1,4 +1,7 @@
-use crate::{style::emphasize, token::{Position, TokenType}};
+use crate::{
+    style::emphasize,
+    token::{Position, TokenType},
+};
 
 use crate::style::{bold, yellow};
 

--- a/lib/src/parser/mod.rs
+++ b/lib/src/parser/mod.rs
@@ -164,7 +164,8 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_expression(&mut self, precedence: Precedence) -> ParserResult<Expr> {
-        let mut left = match self.current_token.clone().tok {
+        let token = self.current_token.clone();
+        let mut left = match token.tok.clone() {
             TokenType::Ident(_) => self.parse_identifier(),
             TokenType::String(_) => self.parse_string(),
             TokenType::Symbol(_) => self.parse_symbol(),
@@ -178,8 +179,7 @@ impl<'a> Parser<'a> {
             TokenType::LeftBracket => self.parse_array(),
             TokenType::LeftBrace => self.parse_hash(),
             tok => {
-                self.no_prefix_parser_error(&tok);
-                return Err(format!("No prefix parser found for {}", &tok));
+                return Err(self.no_prefix_parser_error(token));
             }
         };
         while !self.peek_token_is(&TokenType::Semicolon) && precedence < self.peek_precedence() {
@@ -582,8 +582,9 @@ impl<'a> Parser<'a> {
         }
         msg
     }
-    fn no_prefix_parser_error(&mut self, t: &TokenType) -> String {
-        let msg = format!("No prefix parse function for {:?} found", t);
+    fn no_prefix_parser_error(&mut self, t: Token) -> String {
+        let position = Position::from(self.current_token.offset, self.source.as_str());
+        let msg = format!("On {}, no prefix parse function for {} found", position, t.tok);
         msg
     }
 

--- a/lib/src/parser/mod.rs
+++ b/lib/src/parser/mod.rs
@@ -165,7 +165,7 @@ impl<'a> Parser<'a> {
 
     fn parse_expression(&mut self, precedence: Precedence) -> ParserResult<Expr> {
         let token = self.current_token.clone();
-        let mut left = match token.tok.clone() {
+        let mut left = match token.tok {
             TokenType::Ident(_) => self.parse_identifier(),
             TokenType::String(_) => self.parse_string(),
             TokenType::Symbol(_) => self.parse_symbol(),
@@ -584,7 +584,10 @@ impl<'a> Parser<'a> {
     }
     fn no_prefix_parser_error(&mut self, t: Token) -> String {
         let position = Position::from(self.current_token.offset, self.source.as_str());
-        let msg = format!("On {}, no prefix parse function for {} found", position, t.tok);
+        let msg = format!(
+            "On {}, no prefix parse function for {} found",
+            position, t.tok
+        );
         msg
     }
 

--- a/lib/src/parser/mod.rs
+++ b/lib/src/parser/mod.rs
@@ -1,5 +1,5 @@
 use ast::{BlockStatement, Expr, Ident, Program, Stmt};
-use error::{generate_parser_message, ParserError, ParserResult, ParserType};
+use error::{ParserError, ParserResult, ParserType, generate_parser_message, generate_pretty_error};
 
 use crate::lexer::Lexer;
 use crate::token::{Token, TokenType};
@@ -572,6 +572,8 @@ impl<'a> Parser<'a> {
         let attempted_msg = generate_parser_message(
             ParserError::ExpectedFound(&t.tok, &self.peek_token.tok, position.clone()),
             context.clone(),
+            position.clone(),
+            &self.source
         );
         let mut msg = format!(
             "On line {}, and column {}, we expected next token to be {}, got {} instead. This was in the {:?} parser", position.line, position.column,
@@ -584,10 +586,14 @@ impl<'a> Parser<'a> {
     }
     fn no_prefix_parser_error(&mut self, t: Token) -> String {
         let position = Position::from(self.current_token.offset, self.source.as_str());
-        let msg = format!(
+        let mut msg = format!(
             "On {}, no prefix parse function for {} found",
             position, t.tok
         );
+        let error = generate_pretty_error(position, &self.source);
+        msg.push('\n');
+        msg.push_str(&error);
+
         msg
     }
 

--- a/lib/src/parser/mod.rs
+++ b/lib/src/parser/mod.rs
@@ -1,5 +1,7 @@
 use ast::{BlockStatement, Expr, Ident, Program, Stmt};
-use error::{ParserError, ParserResult, ParserType, generate_parser_message, generate_pretty_error};
+use error::{
+    generate_parser_message, generate_pretty_error, ParserError, ParserResult, ParserType,
+};
 
 use crate::lexer::Lexer;
 use crate::token::{Token, TokenType};
@@ -573,7 +575,7 @@ impl<'a> Parser<'a> {
             ParserError::ExpectedFound(&t.tok, &self.peek_token.tok, position.clone()),
             context.clone(),
             position.clone(),
-            &self.source
+            &self.source,
         );
         let mut msg = format!(
             "On line {}, and column {}, we expected next token to be {}, got {} instead. This was in the {:?} parser", position.line, position.column,

--- a/lib/src/parser/mod.rs
+++ b/lib/src/parser/mod.rs
@@ -178,7 +178,7 @@ impl<'a> Parser<'a> {
             TokenType::Function => self.parse_function(),
             TokenType::LeftBracket => self.parse_array(),
             TokenType::LeftBrace => self.parse_hash(),
-            tok => {
+            _ => {
                 return Err(self.no_prefix_parser_error(token));
             }
         };

--- a/lib/src/parser/parser_test.rs
+++ b/lib/src/parser/parser_test.rs
@@ -243,7 +243,7 @@ fn test_match_expression() {
 
 fn test_output(input: &str, expected: Vec<Stmt>) {
     let l = Lexer::new(input);
-    let mut p = Parser::new(l);
+    let mut p = Parser::new(l, input.to_string());
     let program = p.parse_program();
     if let Ok(program) = program {
         check_program(program, expected);

--- a/lib/src/token.rs
+++ b/lib/src/token.rs
@@ -1,7 +1,23 @@
 use std::fmt;
 
+
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
-pub enum Token {
+pub struct Token {
+    pub tok: TokenType,
+    pub offset: usize
+}
+
+impl Token {
+    pub fn new() -> Token {
+        Token {
+            tok: TokenType::EOF,
+            offset: 0
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+pub enum TokenType {
     Illegal,
     EOF,
 
@@ -64,81 +80,81 @@ pub enum Token {
     Then,
 }
 
-impl fmt::Display for Token {
+impl fmt::Display for TokenType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Token::Ident(value) => write!(f, "{}", value),
-            Token::Number(value) => write!(f, "{}", value),
-            Token::String(value) => write!(f, "'{}'", value),
-            Token::Symbol(value) => write!(f, ":{}", value),
+            TokenType::Ident(value) => write!(f, "{}", value),
+            TokenType::Number(value) => write!(f, "{}", value),
+            TokenType::String(value) => write!(f, "'{}'", value),
+            TokenType::Symbol(value) => write!(f, ":{}", value),
 
-            Token::Assign => write!(f, "="),   // =
-            Token::Plus => write!(f, "+"),     // +
-            Token::Minus => write!(f, "-"),    // -
-            Token::Asterisk => write!(f, "*"), // *
-            Token::Modulus => write!(f, "%"),  // %
-            Token::Slash => write!(f, "/"),    // /
-            Token::Period => write!(f, "."),   // .
-            Token::Arrow => write!(f, "->"),   // ->
-            Token::Range => write!(f, ".."),   // .. (like 0..5)
-            Token::Match => write!(f, "::"),
-            Token::Greater => write!(f, ">"),    // >
-            Token::Less => write!(f, "<"),       // <
-            Token::GreaterEq => write!(f, ">="), // >=
-            Token::LessEq => write!(f, "<="),    // <=
-            Token::Eq => write!(f, "=="),        // ==
-            Token::NotEq => write!(f, "!="),     // !=
-            Token::Bang => write!(f, "!"),       // !
+            TokenType::Assign => write!(f, "="),   // =
+            TokenType::Plus => write!(f, "+"),     // +
+            TokenType::Minus => write!(f, "-"),    // -
+            TokenType::Asterisk => write!(f, "*"), // *
+            TokenType::Modulus => write!(f, "%"),  // %
+            TokenType::Slash => write!(f, "/"),    // /
+            TokenType::Period => write!(f, "."),   // .
+            TokenType::Arrow => write!(f, "->"),   // ->
+            TokenType::Range => write!(f, ".."),   // .. (like 0..5)
+            TokenType::Match => write!(f, "::"),
+            TokenType::Greater => write!(f, ">"),    // >
+            TokenType::Less => write!(f, "<"),       // <
+            TokenType::GreaterEq => write!(f, ">="), // >=
+            TokenType::LessEq => write!(f, "<="),    // <=
+            TokenType::Eq => write!(f, "=="),        // ==
+            TokenType::NotEq => write!(f, "!="),     // !=
+            TokenType::Bang => write!(f, "!"),       // !
 
-            Token::And => write!(f, "&&"),
-            Token::Or => write!(f, "||"),
+            TokenType::And => write!(f, "&&"),
+            TokenType::Or => write!(f, "||"),
 
-            Token::Comma => write!(f, ","),
-            Token::Semicolon => write!(f, ";"),
-            Token::Colon => write!(f, ":"), // :
+            TokenType::Comma => write!(f, ","),
+            TokenType::Semicolon => write!(f, ";"),
+            TokenType::Colon => write!(f, ":"), // :
 
             // Braces 'n stuff
-            Token::LeftParen => write!(f, "("),
-            Token::RightParen => write!(f, ")"),
-            Token::LeftBrace => write!(f, "{{"),
-            Token::RightBrace => write!(f, "}}"),
-            Token::LeftBracket => write!(f, "["),
-            Token::RightBracket => write!(f, "]"),
+            TokenType::LeftParen => write!(f, "("),
+            TokenType::RightParen => write!(f, ")"),
+            TokenType::LeftBrace => write!(f, "{{"),
+            TokenType::RightBrace => write!(f, "}}"),
+            TokenType::LeftBracket => write!(f, "["),
+            TokenType::RightBracket => write!(f, "]"),
 
             // Keywords
             // Might be better to split off into a second enum
 
             // Import related
-            Token::Import => write!(f, "import"),
-            Token::From => write!(f, "from"),
-            Token::As => write!(f, "as"),
+            TokenType::Import => write!(f, "import"),
+            TokenType::From => write!(f, "from"),
+            TokenType::As => write!(f, "as"),
 
-            Token::Return => write!(f, "return"),
-            Token::Function => write!(f, "fn"),
-            Token::True => write!(f, "true"),
-            Token::False => write!(f, "false"),
-            Token::If => write!(f, "if"),
-            Token::Else => write!(f, "else"),
-            Token::Then => write!(f, "then"),
+            TokenType::Return => write!(f, "return"),
+            TokenType::Function => write!(f, "fn"),
+            TokenType::True => write!(f, "true"),
+            TokenType::False => write!(f, "false"),
+            TokenType::If => write!(f, "if"),
+            TokenType::Else => write!(f, "else"),
+            TokenType::Then => write!(f, "then"),
 
-            Token::EOF => write!(f, "EOF"),
+            TokenType::EOF => write!(f, "EOF"),
             _ => write!(f, ""),
         }
     }
 }
 
-pub fn lookup_keyword(name: &str) -> Token {
+pub fn lookup_keyword(name: &str) -> TokenType {
     match name {
-        "import" => Token::Import,
-        "from" => Token::From,
-        "as" => Token::As,
-        "fn" => Token::Function,
-        "return" => Token::Return,
-        "true" => Token::True,
-        "false" => Token::False,
-        "if" => Token::If,
-        "then" => Token::Then,
-        "else" => Token::Else,
-        _ => Token::Ident(name.to_string()),
+        "import" => TokenType::Import,
+        "from" => TokenType::From,
+        "as" => TokenType::As,
+        "fn" => TokenType::Function,
+        "return" => TokenType::Return,
+        "true" => TokenType::True,
+        "false" => TokenType::False,
+        "if" => TokenType::If,
+        "then" => TokenType::Then,
+        "else" => TokenType::Else,
+        _ => TokenType::Ident(name.to_string()),
     }
 }

--- a/lib/src/token.rs
+++ b/lib/src/token.rs
@@ -8,24 +8,25 @@ pub struct Position {
 
 impl Position {
     pub fn from(offset: usize, source: &str) -> Position {
-        let lines = source.split('\n');
-        let mut line = 0;
+        let mut total = 0;
+        let mut line = 1;
         let mut column = 0;
 
-        let mut current = 0;
+        for ch in source.chars() {
+            if ch == '\n' {
+                line += 1;
+                column = 0;
+            } else {
+                column += 1;
+            }
 
-        for (index, current_line) in lines.enumerate() {
-            // Account for the newline
-            current += current_line.len() + 1;
-            // It's in this line
-            if offset < current {
-                line = index + 1;
-                // I honestly don't even know why this needs the minus 2, but it works so i'm not complaining
-                column = current - offset + 2;
-                break;
+            total += 1;
+
+            if offset < total {
+                break
             }
         }
-
+        
         Position { line, column }
     }
 }

--- a/lib/src/token.rs
+++ b/lib/src/token.rs
@@ -15,11 +15,13 @@ impl Position {
         let mut current = 0;
 
         for (index, current_line) in lines.enumerate() {
-            current += current_line.len();
+            // Account for the newline
+            current += current_line.len() + 1;
             // It's in this line
             if offset < current {
-                line = index;
-                column = current - offset;
+                line = index + 1;
+                // I honestly don't even know why this needs the minus 2, but it works so i'm not complaining
+                column = current - offset + 2;
                 break;
             }
         }

--- a/lib/src/token.rs
+++ b/lib/src/token.rs
@@ -23,10 +23,10 @@ impl Position {
             total += 1;
 
             if offset < total {
-                break
+                break;
             }
         }
-        
+
         Position { line, column }
     }
 }

--- a/lib/src/token.rs
+++ b/lib/src/token.rs
@@ -1,17 +1,56 @@
 use std::fmt;
 
+#[derive(Debug, Clone)]
+pub struct Position {
+    pub line: usize,
+    pub column: usize,
+}
+
+impl Position {
+    pub fn from(offset: usize, source: &str) -> Position {
+        let lines = source.split('\n');
+        let mut line = 0;
+        let mut column = 0;
+
+        let mut current = 0;
+
+        for (index, current_line) in lines.enumerate() {
+            current += current_line.len();
+            // It's in this line
+            if offset < current {
+                line = index;
+                column = current - offset;
+                break;
+            }
+        }
+
+        Position { line, column }
+    }
+}
+
+impl fmt::Display for Position {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "line {}, column {}", self.line, self.column)
+    }
+}
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub struct Token {
     pub tok: TokenType,
-    pub offset: usize
+    pub offset: usize,
+}
+
+impl Default for Token {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl Token {
     pub fn new() -> Token {
         Token {
             tok: TokenType::EOF,
-            offset: 0
+            offset: 0,
         }
     }
 }

--- a/src/file.rs
+++ b/src/file.rs
@@ -17,7 +17,7 @@ pub fn exec_file(path: &Path) -> std::io::Result<()> {
     let file = fs::read_to_string(path)?;
 
     let lexer = Lexer::new(&file);
-    let mut parser = Parser::new(lexer);
+    let mut parser = Parser::new(lexer, file.to_string());
 
     let program = match parser.parse_program() {
         Ok(program) => program,

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -44,7 +44,7 @@ pub fn start() {
 
 fn eval(line: &str, context: &mut Context, eval: &mut Evaluator) {
     let l = lexer::Lexer::new(line);
-    let mut p = Parser::new(l);
+    let mut p = Parser::new(l, line.to_string());
 
     let program = p.parse_program();
     if let Ok(program) = program {


### PR DESCRIPTION
Closes #6 

This follows the approach of using a separate struct (now called `Token`) to include our `TokenType` and the offset of a token. All tests pass, but as of now, there is no use of this field

## Todos

- [x] Implement basic debugging information (this error on this line and this column)
- [x] Implement good debugging information