### PR TITLE
Improve pattern matching

### DIFF
--- a/examples/fib.bliss
+++ b/examples/fib.bliss
@@ -1,12 +1,12 @@
-fib = fn n -> {
+let fib = fn n -> {
   if n < 2 {
     return n;
   } else {
-    return fib(n - 1) = fib(n - 2)
+    return fib(n - 1) + fib(n - 2)
   }
 }
 
-tail_fib = fn (n, a, b) -> {
+let tail_fib = fn (n, a, b) -> {
   if n == 0 {
     return a
   } else {
@@ -19,5 +19,4 @@ tail_fib = fn (n, a, b) -> {
   }
 }
 
-fib(3)
-tail_fib(3, 0, 1)
+log(tail_fib(3, 0, 1))

--- a/lib/src/ast.rs
+++ b/lib/src/ast.rs
@@ -1,3 +1,4 @@
+use std::convert::TryInto;
 use std::fmt;
 #[derive(PartialEq, Clone, Debug, Eq, PartialOrd)]
 pub struct Ident(pub String);
@@ -20,10 +21,10 @@ impl fmt::Display for Ident {
 
 #[derive(Debug, PartialEq, PartialOrd, Clone)]
 pub enum Stmt {
-    Assign(Expr, Expr),
+    Assign(Pattern, Expr),
     Return(Expr),
     Expr(Expr),
-    Import { source: Expr, name: Expr },
+    Import { source: Expr, name: Pattern },
 }
 
 impl Into<BlockStatement> for Stmt {
@@ -47,6 +48,7 @@ impl fmt::Display for Stmt {
 pub enum Expr {
     Number(f64),
     Ident(Ident),
+    Pattern(Pattern),
     Prefix(String, Box<Expr>),
     Infix(Box<Expr>, String, Box<Expr>),
     Boolean(bool),
@@ -67,7 +69,7 @@ pub enum Expr {
     },
     Match {
         condition: Box<Expr>,
-        cases: Vec<(Expr, BlockStatement)>,
+        cases: Vec<(Pattern, BlockStatement)>,
     },
     // Array data structure
     Array(Vec<Expr>),
@@ -120,6 +122,7 @@ impl fmt::Display for Expr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Expr::Ident(ident) => write!(f, "{}", ident.0),
+            Expr::Pattern(pattern) => write!(f, "{}", pattern),
             Expr::Number(num) => write!(f, "{}", num),
             Expr::Prefix(op, expr) => write!(f, "({}{})", op, expr),
             Expr::Infix(left, operator, right) => write!(f, "({} {} {})", left, operator, right),
@@ -226,3 +229,50 @@ impl fmt::Display for BlockStatement {
     }
 }
 pub type Program = BlockStatement;
+
+#[derive(Debug, PartialEq, PartialOrd, Clone)]
+pub enum Pattern {
+    String(String),
+    Number(f64),
+    Boolean(bool),
+    Symbol(String),
+    Ident(Ident),
+    // Array destructuring
+    Array(Vec<Pattern>),
+    // Hashmap destructing
+    Hash(Vec<(Ident, Option<Ident>)>),
+    Nothing,
+}
+
+impl fmt::Display for Pattern {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Pattern::Ident(id) => id.fmt(f),
+            Pattern::Number(num) => num.fmt(f),
+            Pattern::Boolean(b) => b.fmt(f),
+            Pattern::Symbol(sym) => write!(f, ":{}", sym),
+            Pattern::String(str) => write!(f, "'{}'", str),
+            Pattern::Nothing => write!(f, "_"),
+            Pattern::Array(items) => {
+                let x: Vec<String> = items.iter().map(|item| format!("{}", item)).collect();
+                write!(f, "[ {} ]", x.join(","))
+            }
+            Pattern::Hash(items) => {
+                let x: Vec<String> = items
+                    .iter()
+                    .map(|(key, alias)| match alias {
+                        Some(alias) => format!("{}: {}", key, alias),
+                        None => format!("{}", key),
+                    })
+                    .collect();
+                write!(f, "{{ {} }}", x.join(","))
+            }
+        }
+    }
+}
+
+impl From<Ident> for Pattern {
+    fn from(ident: Ident) -> Pattern {
+        Pattern::Ident(ident)
+    }
+}

--- a/lib/src/ast.rs
+++ b/lib/src/ast.rs
@@ -1,4 +1,3 @@
-use std::convert::TryInto;
 use std::fmt;
 #[derive(PartialEq, Clone, Debug, Eq, PartialOrd)]
 pub struct Ident(pub String);

--- a/lib/src/evaluation/builtins.rs
+++ b/lib/src/evaluation/builtins.rs
@@ -4,7 +4,7 @@ use std::cell::RefCell;
 
 use super::{object::Object, EvalResult, Evaluator};
 
-pub fn get_builtins() -> HashMap<String, Object> {
+pub fn get_builtins<'a>() -> HashMap<String, Object<'a>> {
     let mut builtins = HashMap::new();
 
     // Array functions
@@ -21,7 +21,7 @@ pub fn get_builtins() -> HashMap<String, Object> {
     builtins
 }
 
-fn len(args: Vec<Object>, _: Rc<RefCell<Evaluator>>) -> EvalResult {
+fn len<'a>(args: Vec<Object<'a>>, _: Rc<RefCell<Evaluator>>) -> EvalResult<'a> {
     let arg = args[0].clone();
     let len = match arg {
         Object::Array(arr) => arr.len(),
@@ -37,27 +37,27 @@ fn len(args: Vec<Object>, _: Rc<RefCell<Evaluator>>) -> EvalResult {
     Ok(Object::Number(len as f64))
 }
 
-fn log(args: Vec<Object>, _: Rc<RefCell<Evaluator>>) -> EvalResult {
+fn log<'a>(args: Vec<Object>, _: Rc<RefCell<Evaluator>>) -> EvalResult<'a> {
     for arg in args {
         println!("{}", arg);
     }
     Ok(Object::Void)
 }
 
-fn init(args: Vec<Object>, _: Rc<RefCell<Evaluator>>) -> EvalResult {
+fn init<'a>(args: Vec<Object<'a>>, _: Rc<RefCell<Evaluator>>) -> EvalResult<'a> {
     if let Object::Array(array) = args[0].clone() {
         return Ok(Object::Array(array[0..array.len() - 1].to_vec()));
     };
     Err(format!("{} isn't an array", args[0]))
 }
-fn tail(args: Vec<Object>, _: Rc<RefCell<Evaluator>>) -> EvalResult {
+fn tail<'a>(args: Vec<Object<'a>>, _: Rc<RefCell<Evaluator>>) -> EvalResult<'a> {
     if let Object::Array(array) = args[0].clone() {
         return Ok(Object::Array(array[1..array.len()].to_vec()));
     };
     Err(format!("{} isn't an array", args[0]))
 }
 
-fn head(args: Vec<Object>, _: Rc<RefCell<Evaluator>>) -> EvalResult {
+fn head<'a>(args: Vec<Object<'a>>, _: Rc<RefCell<Evaluator>>) -> EvalResult<'a> {
     if let Object::Array(array) = args[0].clone() {
         return match array.first() {
             Some(val) => Ok(val.clone()),
@@ -67,7 +67,7 @@ fn head(args: Vec<Object>, _: Rc<RefCell<Evaluator>>) -> EvalResult {
     Err(format!("{} isn't an array", args[0]))
 }
 
-fn last(args: Vec<Object>, _: Rc<RefCell<Evaluator>>) -> EvalResult {
+fn last<'a>(args: Vec<Object<'a>>, _: Rc<RefCell<Evaluator>>) -> EvalResult<'a> {
     if let Object::Array(array) = args[0].clone() {
         return match array.last() {
             Some(val) => Ok(val.clone()),
@@ -77,7 +77,7 @@ fn last(args: Vec<Object>, _: Rc<RefCell<Evaluator>>) -> EvalResult {
     Err(format!("{} isn't an array", args[0]))
 }
 
-fn map(args: Vec<Object>, eval: Rc<RefCell<Evaluator>>) -> EvalResult {
+fn map<'a>(args: Vec<Object<'a>>, eval: Rc<RefCell<Evaluator<'a>>>) -> EvalResult<'a> {
     if let Object::Array(array) = args[0].clone() {
         match args[1].clone() {
             Object::Function {

--- a/lib/src/evaluation/env.rs
+++ b/lib/src/evaluation/env.rs
@@ -4,52 +4,60 @@ use std::collections::HashMap;
 use std::cell::RefCell;
 use std::rc::Rc;
 
+type Env<'a> = Rc<RefCell<Environment<'a>>>;
+
 #[derive(PartialEq, Clone, Debug)]
-pub struct Environment {
-    store: HashMap<String, Object>,
-    parent: Option<Rc<RefCell<Environment>>>,
+pub struct Environment<'a> {
+    store: HashMap<String, Object<'a>>,
+    parent: Option<Env<'a>>,
 }
 
-impl Default for Environment {
+impl<'a> Default for Environment<'a> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl Environment {
-    pub fn new() -> Environment {
+impl<'a> Environment<'a> {
+    pub fn new() -> Environment<'a> {
         Environment {
             store: HashMap::new(),
             parent: None,
         }
     }
 
-    pub fn get_store(&self) -> &HashMap<String, Object> {
+    pub fn get_store(&self) -> &HashMap<String, Object<'a>> {
         &self.store
     }
 
-    pub fn new_enclosed(parent: Rc<RefCell<Environment>>) -> Environment {
+    pub fn new_enclosed(parent: &Env<'a>) -> Self {
         Environment {
             store: HashMap::new(),
-            parent: Some(parent),
+            parent: Some(parent.clone()),
         }
     }
 
-    pub fn get(&self, key: String) -> Option<Object> {
+    pub fn get(&self, key: String) -> Option<Object<'a>> {
         match self.store.get(&key) {
             Some(value) => Some(value.clone()),
             None => match self.parent {
-                Some(ref parent) => parent.borrow_mut().get(key),
+                Some(ref parent) => parent.borrow().get(key),
                 None => None,
             },
         }
     }
 
-    pub fn set(&mut self, key: String, value: Object) {
+    pub fn set(&mut self, key: String, value: Object<'a>) {
         self.store.insert(key, value);
     }
 
     pub fn has(&self, key: &str) -> bool {
         self.store.contains_key(key)
+    }
+}
+
+impl<'a> From<Environment<'a>> for Rc<RefCell<Environment<'a>>> {
+    fn from(val: Environment<'a>) -> Self {
+        Rc::new(RefCell::new(val))
     }
 }

--- a/lib/src/evaluation/mod.rs
+++ b/lib/src/evaluation/mod.rs
@@ -6,24 +6,25 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
 
-use crate::ast::{BlockStatement, Expr, Program, Stmt};
+use crate::ast::{BlockStatement, Expr, Ident, Pattern, Program, Stmt};
 use env::Environment;
 use object::Object;
 
-type EvalResult = Result<Object, String>;
+type EvalResult<'a> = Result<Object<'a>, String>;
 #[derive(Debug, Clone)]
-pub struct Evaluator {
-    env: Rc<RefCell<Environment>>,
+pub struct Evaluator<'a> {
+    env: Rc<RefCell<Environment<'a>>>,
 }
-impl Evaluator {
-    pub fn new(env: Rc<RefCell<Environment>>) -> Self {
+impl<'a> Evaluator<'a> {
+    pub fn new(env: Rc<RefCell<Environment<'a>>>) -> Self {
         let builtins = builtins::get_builtins();
         for (name, value) in builtins {
-            env.borrow_mut().set(name, value);
+            let mut inner_env = env.borrow_mut();
+            inner_env.set(name, value);
         }
         Self { env }
     }
-    pub fn eval_program(&mut self, program: Program) -> EvalResult {
+    pub fn eval_program(&mut self, program: Program) -> EvalResult<'a> {
         let mut result = Object::Void;
         for stmt in program.0 {
             match self.eval_stmt(stmt)? {
@@ -34,7 +35,7 @@ impl Evaluator {
         Ok(result)
     }
 
-    fn eval_block_stmt(&mut self, stmts: BlockStatement) -> EvalResult {
+    fn eval_block_stmt(&mut self, stmts: BlockStatement) -> EvalResult<'a> {
         let mut result = Object::Void;
         for stmt in stmts.0 {
             match self.eval_stmt(stmt)? {
@@ -45,7 +46,7 @@ impl Evaluator {
         Ok(result)
     }
 
-    fn eval_stmt(&mut self, stmt: Stmt) -> EvalResult {
+    fn eval_stmt(&mut self, stmt: Stmt) -> EvalResult<'a> {
         match stmt {
             Stmt::Expr(expr) => self.eval_expr(expr),
             Stmt::Return(expr) => {
@@ -55,13 +56,13 @@ impl Evaluator {
             Stmt::Assign(name, value) => {
                 let value = self.eval_expr(value)?;
                 match name {
-                    Expr::Ident(ident) => {
+                    Pattern::Ident(ident) => {
                         self.env.borrow_mut().set(ident.0, value);
                     }
-                    Expr::Array(names) => {
+                    Pattern::Array(names) => {
                         if let Object::Array(values) = value {
                             names.iter().enumerate().for_each(|(index, name)| {
-                                if let Expr::Ident(name) = name {
+                                if let Pattern::Ident(name) = name {
                                     self.env
                                         .borrow_mut()
                                         .set(name.0.clone(), values[index].clone())
@@ -77,7 +78,7 @@ impl Evaluator {
         }
     }
 
-    fn eval_expr(&mut self, node: Expr) -> EvalResult {
+    fn eval_expr(&mut self, node: Expr) -> EvalResult<'a> {
         match node {
             Expr::Number(value) => Ok(Object::Number(value)),
             Expr::String(value) => Ok(Object::String(value)),
@@ -116,7 +117,10 @@ impl Evaluator {
             Expr::Match { condition, cases } => self.eval_match_expression(*condition, cases),
             Expr::Ident(name) => match self.env.borrow().get(name.0.clone()) {
                 Some(value) => Ok(value),
-                None => Err(format!("Identifier not found: {}", name)),
+                None => {
+                    // println!("{:#?}", self.env);
+                    Err(format!("Identifier not found: {}", name))
+                }
             },
             Expr::Call {
                 function,
@@ -125,13 +129,18 @@ impl Evaluator {
             Expr::Function { parameters, body } => Ok(Object::Function {
                 parameters,
                 body,
-                env: Rc::clone(&self.env),
+                env: Environment::new_enclosed(&self.env).into(),
             }),
+            Expr::Symbol(sym) => Ok(Object::Symbol(sym)),
             _ => Err(format!("Unable to evaluate node: {}", node)),
         }
     }
 
-    fn eval_function_call(&mut self, function: Object, args: Vec<Object>) -> EvalResult {
+    fn eval_function_call(
+        &mut self,
+        function: Object<'a>,
+        args: Vec<Object<'a>>,
+    ) -> EvalResult<'a> {
         let (params, body, env) = match function {
             Object::Function {
                 parameters,
@@ -139,7 +148,7 @@ impl Evaluator {
                 env,
             } => (parameters, body, env),
             Object::Builtin(params, func) => {
-                if params < 0 || params == (args.len() as i32) {
+                if params < 0 || params == (args.len() as isize) {
                     return func(args, Rc::new(RefCell::new(self.clone())));
                 }
                 return Err(format!(
@@ -158,8 +167,7 @@ impl Evaluator {
             ));
         }
 
-        let current_env = Rc::clone(&env);
-        let mut function_env = Environment::new_enclosed(Rc::clone(&current_env));
+        let mut function_env = Environment::new_enclosed(&Rc::clone(&env));
         params
             .iter()
             .enumerate()
@@ -167,11 +175,11 @@ impl Evaluator {
         self.env = Rc::new(RefCell::new(function_env));
         let res = self.eval_block_stmt(body)?;
 
-        self.env = current_env;
+        self.env = env;
         Ok(res)
     }
 
-    fn eval_call_expression(&mut self, function: Expr, arguments: Vec<Expr>) -> EvalResult {
+    fn eval_call_expression(&mut self, function: Expr, arguments: Vec<Expr>) -> EvalResult<'a> {
         let function = self.eval_expr(function)?;
         let mut args = vec![];
         for arg in arguments {
@@ -186,7 +194,7 @@ impl Evaluator {
                 env,
             } => (parameters, body, env),
             Object::Builtin(params, func) => {
-                if params < 0 || params == (args.len() as i32) {
+                if params < 0 || params == (args.len() as isize) {
                     return func(args, Rc::new(RefCell::new(self.clone())));
                 }
                 return Err(format!(
@@ -206,7 +214,7 @@ impl Evaluator {
         }
 
         let current_env = Rc::clone(&env);
-        let mut function_env = Environment::new_enclosed(Rc::clone(&current_env));
+        let mut function_env = Environment::new_enclosed(&current_env);
         params
             .iter()
             .enumerate()
@@ -214,15 +222,15 @@ impl Evaluator {
         self.env = Rc::new(RefCell::new(function_env));
         let res = self.eval_block_stmt(body)?;
 
-        self.env = current_env;
+        self.env = env;
         Ok(res)
     }
 
     fn eval_match_expression(
         &mut self,
         condition: Expr,
-        cases: Vec<(Expr, BlockStatement)>,
-    ) -> EvalResult {
+        cases: Vec<(Pattern, BlockStatement)>,
+    ) -> EvalResult<'a> {
         let condition = self.eval_expr(condition)?;
         let current = Rc::clone(&self.env);
         let mut result = Object::Void;
@@ -240,7 +248,7 @@ impl Evaluator {
         Ok(result)
     }
 
-    fn eval_match_case(&mut self, case: Object, condition: Object) -> bool {
+    fn eval_match_case(&mut self, case: Object<'a>, condition: Object<'a>) -> bool {
         match case {
             Object::Array(array) => {
                 if let Object::Array(condition) = condition {
@@ -262,34 +270,61 @@ impl Evaluator {
 
     fn eval_pattern_matching(
         &mut self,
-        env: &Rc<RefCell<Environment>>,
-        case: Expr,
-        condition: Object,
-    ) -> EvalResult {
+        env: &Rc<RefCell<Environment<'a>>>,
+        case: Pattern,
+        condition: Object<'a>,
+    ) -> EvalResult<'a> {
         let value = match case {
-            Expr::Ident(ident) => {
-                if &ident.0 == "_" {
-                    Object::Ident(ident)
-                } else {
-                    env.borrow_mut().set(ident.0, condition.clone());
-                    condition
-                }
+            Pattern::Nothing => Object::Ident(Ident::from("_")),
+            Pattern::Ident(ident) => {
+                env.borrow_mut().set(ident.0, condition.clone());
+                condition
             }
-            Expr::Array(array) => {
+            Pattern::Array(array) => {
                 let mut arr = vec![];
-                for element in array {
-                    let result = self.eval_pattern_matching(env, element, condition.clone())?;
+                let condition_array = match condition {
+                    Object::Array(a) => a,
+                    _ => return Err("Mismatched types".to_string()),
+                };
+                for (pattern, condition) in array.iter().zip(condition_array) {
+                    let result =
+                        self.eval_pattern_matching(env, pattern.clone(), condition.clone())?;
                     arr.push(result);
                 }
                 Object::Array(arr)
             }
-            _ => self.eval_expr(case)?,
+            Pattern::Hash(hash) => {
+                let mut arr = vec![];
+                let condition_hash = match condition {
+                    Object::Hash(a) => a,
+                    _ => return Err("Mismatched types".to_string()),
+                };
+                for (key, alias) in hash {
+                    let condition = match condition_hash.get(&key.0) {
+                        Some(cond) => cond,
+                        None => &Object::Null,
+                    };
+                    let pattern = Pattern::Ident(alias.unwrap_or(key));
+                    let result = self.eval_pattern_matching(env, pattern, condition.clone())?;
+                    arr.push(result);
+                }
+                Object::Array(arr)
+            }
+            Pattern::String(str) => Object::String(str),
+            Pattern::Number(num) => Object::Number(num),
+            Pattern::Symbol(str) => Object::Symbol(str),
+            Pattern::Boolean(bool) => Object::Boolean(bool),
         };
 
         Ok(value)
     }
 
-    fn eval_infix_expression(&self, left: Object, operator: &str, right: Object) -> EvalResult {
+    fn eval_infix_expression(
+        &self,
+        left: Object<'a>,
+        operator: &str,
+        right: Object<'a>,
+    ) -> EvalResult<'a> {
         match operator {
             "+" => self.eval_plus_operator(left, right),
             "-" | "*" | "/" | "%" | ">" | "<" | ">=" | "<=" => {
@@ -301,7 +336,7 @@ impl Evaluator {
         }
     }
 
-    fn eval_prefix_expression(&self, operator: &str, right: Object) -> EvalResult {
+    fn eval_prefix_expression(&self, operator: &str, right: Object) -> EvalResult<'a> {
         match operator {
             "!" => Ok(self.eval_bang_operator(right)),
             "-" => {
@@ -314,7 +349,7 @@ impl Evaluator {
         }
     }
 
-    fn eval_number_operator(&self, left: Object, operator: &str, right: Object) -> EvalResult {
+    fn eval_number_operator(&self, left: Object, operator: &str, right: Object) -> EvalResult<'a> {
         let result = if let Object::Number(left) = left {
             if let Object::Number(right) = right {
                 match operator {
@@ -345,7 +380,12 @@ impl Evaluator {
         Ok(result)
     }
 
-    fn eval_boolean_operator(&self, left: Object, operator: &str, right: Object) -> EvalResult {
+    fn eval_boolean_operator(
+        &self,
+        left: Object<'a>,
+        operator: &str,
+        right: Object<'a>,
+    ) -> EvalResult<'a> {
         match operator {
             "==" => Ok(Self::native_bool_to_object(left == right)),
             "!=" => Ok(Self::native_bool_to_object(left != right)),
@@ -353,7 +393,7 @@ impl Evaluator {
         }
     }
 
-    fn eval_range_operator(&self, left: Object, right: Object) -> EvalResult {
+    fn eval_range_operator(&self, left: Object<'a>, right: Object<'a>) -> EvalResult<'a> {
         if let Object::Number(left) = left {
             if let Object::Number(right) = right {
                 let left = left.round() as i64;
@@ -372,7 +412,7 @@ impl Evaluator {
         ))
     }
 
-    fn eval_plus_operator(&self, left: Object, right: Object) -> EvalResult {
+    fn eval_plus_operator(&self, left: Object<'a>, right: Object<'a>) -> EvalResult<'a> {
         match left {
             Object::Number(left) => {
                 if let Object::Number(right) = right {
@@ -398,7 +438,7 @@ impl Evaluator {
         }
     }
 
-    fn eval_bang_operator(&self, right: Object) -> Object {
+    fn eval_bang_operator(&self, right: Object) -> Object<'a> {
         Self::native_bool_to_object(!Self::is_truthy(right))
     }
 
@@ -407,7 +447,7 @@ impl Evaluator {
         condition: Expr,
         consequence: BlockStatement,
         alternative: BlockStatement,
-    ) -> EvalResult {
+    ) -> EvalResult<'a> {
         let condition = self.eval_expr(condition)?;
         if Self::is_truthy(condition) {
             self.eval_block_stmt(consequence)
@@ -416,7 +456,7 @@ impl Evaluator {
         }
     }
 
-    fn native_bool_to_object(input: bool) -> Object {
+    fn native_bool_to_object(input: bool) -> Object<'a> {
         if input {
             Object::Boolean(true)
         } else {
@@ -425,6 +465,6 @@ impl Evaluator {
     }
 
     fn is_truthy(input: Object) -> bool {
-        matches!(input, Object::Boolean(false))
+        matches!(input, Object::Boolean(true))
     }
 }

--- a/lib/src/lexer/lexer_test.rs
+++ b/lib/src/lexer/lexer_test.rs
@@ -38,9 +38,9 @@ fn test_two_chars() {
         Token::LessEq,
         Token::Ident(String::from("e")),
         Token::Match,
-        Token::Number(String::from("0")),
+        Token::Number(0.0),
         Token::Range,
-        Token::Number(String::from("5")),
+        Token::Number(5.0),
         Token::Arrow,
     ];
     test_tokens(input, tests);
@@ -84,15 +84,22 @@ fn test_keywords() {
 
 #[test]
 fn test_numbers() {
-    let input = "5 + 4 * 8000";
+    let input = "5 + 4.5 * 8000";
     let tests = vec![
-        Token::Number(String::from("5")),
+        Token::Number(5.0),
         Token::Plus,
-        Token::Number(String::from("4")),
+        Token::Number(4.5),
         Token::Asterisk,
-        Token::Number(String::from("8000")),
+        Token::Number(8000.0),
     ];
     test_tokens(input, tests);
+}
+
+#[test]
+fn test_float_lookahead() {
+    let input = "1..3";
+    let tests = vec![Token::Number(1.0), Token::Range, Token::Number(3.0)];
+    test_tokens(input, tests)
 }
 
 #[test]

--- a/lib/src/lexer/mod.rs
+++ b/lib/src/lexer/mod.rs
@@ -25,6 +25,16 @@ impl<'a> Lexer<'a> {
     fn peek(&mut self) -> Option<&char> {
         self.input.peek()
     }
+
+    fn multipeek(&mut self, dist: usize) -> Option<char> {
+        let mut clone = self.input.clone();
+        let mut ch = clone.next();
+        for _ in 1..dist {
+            ch = clone.next();
+        }
+        ch
+    }
+
     fn read(&mut self) -> Option<char> {
         self.input.next()
     }
@@ -105,7 +115,10 @@ impl<'a> Lexer<'a> {
                     return token::lookup_keyword(ident.as_str());
                 } else if Self::is_digit(ch) {
                     let number = self.read_number(ch);
-                    return Token::Number(number);
+                    match number {
+                        Some(number) => return Token::Number(number),
+                        None => return Token::Illegal,
+                    }
                 }
                 Token::Illegal
             }
@@ -132,11 +145,22 @@ impl<'a> Lexer<'a> {
     fn is_digit(ch: char) -> bool {
         ch.is_ascii_digit()
     }
+    fn is_dot(ch: char) -> bool {
+        ch == '.'
+    }
 
     // Takes a function like &Self::is_letter
     fn peek_fn(&mut self, f: &IsFunc) -> bool {
         match self.peek() {
             Some(&ch) => f(ch),
+            None => false,
+        }
+    }
+
+    // Takes a function like &Self::is_letter
+    fn multipeek_fn(&mut self, dist: usize, f: &IsFunc) -> bool {
+        match self.multipeek(dist) {
+            Some(ch) => f(ch),
             None => false,
         }
     }
@@ -158,14 +182,28 @@ impl<'a> Lexer<'a> {
         Number(5), Period, Number(6)
       That unambiguously translates to Number(5.6) (i hope)
     */
-    fn read_number(&mut self, initial: char) -> String {
+    fn read_number(&mut self, initial: char) -> Option<f64> {
         let mut number = String::from(initial);
-        while self.peek_fn(&Self::is_digit) {
+        let mut dot = false;
+        while self.peek_fn(&Self::is_digit)
+        // Prevent reading the range operator
+            || (self.peek_fn(&Self::is_dot) && !self.multipeek_fn(2, &Self::is_dot))
+        {
             if let Some(ch) = self.read() {
+                if ch == '.' {
+                    if !dot {
+                        dot = true;
+                    } else {
+                        return None;
+                    }
+                }
                 number.push(ch)
             }
         }
-        number
+        match number.parse() {
+            Ok(num) => Some(num),
+            Err(_) => None,
+        }
     }
     // TODO: Add support for escapes, like \"
     fn read_string(&mut self, initial: char) -> String {

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -2,6 +2,6 @@ mod ast;
 pub mod evaluation;
 pub mod lexer;
 pub mod parser;
-pub mod semantics;
+// pub mod semantics;
 pub mod style;
 pub mod token;

--- a/lib/src/parser/error.rs
+++ b/lib/src/parser/error.rs
@@ -22,6 +22,7 @@ pub enum ParserType {
     Match,
     Array,
     Hash,
+    Pattern,
 }
 pub enum ParserError<'a> {
     ExpectedFound(&'a Token, &'a Token),

--- a/lib/src/parser/parser_test.rs
+++ b/lib/src/parser/parser_test.rs
@@ -5,9 +5,9 @@ use crate::lexer::Lexer;
 #[test]
 fn test_assign_stmt() {
     let input = "
-	x = 5;
-	y = 10;
-	foobar = 838383;
+	let x = 5;
+	let y = 10;
+	let foobar = 838383;
 	";
     let expected = vec![
         Stmt::Assign(Ident::from("x").into(), Expr::Number(5.0)),

--- a/lib/src/parser/parser_test.rs
+++ b/lib/src/parser/parser_test.rs
@@ -181,13 +181,10 @@ fn test_array_expression() {
 fn test_hash_expression() {
     let input = "{ name = 'bob', age = 15, height, status = :online }";
     let expected = Expr::Hash(vec![
-        (Ident::from("name").into(), Expr::from("bob")),
-        (Ident::from("age").into(), Expr::from(15.0)),
-        (Ident::from("height").into(), Ident::from("height").into()),
-        (
-            Ident::from("status").into(),
-            Expr::Symbol("online".to_string()),
-        ),
+        (Ident::from("name"), Expr::from("bob")),
+        (Ident::from("age"), Expr::from(15.0)),
+        (Ident::from("height"), Ident::from("height").into()),
+        (Ident::from("status"), Expr::Symbol("online".to_string())),
     ])
     .into();
     test_output(input, expected)
@@ -209,6 +206,35 @@ fn test_call_expression() {
 }
 
 #[test]
+fn test_pattern() {
+    let input = "[ 4.5, foo, true, :bar, 'hello', { abc, def }, _ ]";
+    let expected = Pattern::Array(vec![
+        Pattern::Number(4.5),
+        Pattern::Ident(Ident::from("foo")),
+        Pattern::Boolean(true),
+        Pattern::Symbol("bar".to_string()),
+        Pattern::String("hello".to_string()),
+        Pattern::Hash(vec![(Ident::from("abc"), None), (Ident::from("def"), None)]),
+        Pattern::Nothing,
+    ]);
+
+    // Specialized check
+    fn test_output(input: &str, expected: Pattern) {
+        let l = Lexer::new(input);
+        let mut p = Parser::new(l);
+        let pattern = p.parse_pattern();
+        if let Ok(pattern) = pattern {
+            assert_eq!(pattern, expected)
+        } else if let Err(err) = pattern {
+            println!("Parser had an error:\n{}", err);
+            assert!(false);
+        }
+    }
+
+    test_output(input, expected)
+}
+
+#[test]
 fn test_match_expression() {
     let input = "true :: {
         true -> 1 + 1,
@@ -218,20 +244,20 @@ fn test_match_expression() {
         condition: Expr::from(true).into(),
         cases: vec![
             (
-                Expr::from(true),
+                Pattern::Boolean(true),
                 Expr::Infix(
-                    Box::new(Expr::from(1.0).into()),
+                    Box::new(Expr::from(1.0)),
                     String::from("+"),
-                    Box::new(Expr::from(1.0).into()),
+                    Box::new(Expr::from(1.0)),
                 )
                 .into(),
             ),
             (
-                Expr::from(false),
+                Pattern::Boolean(false),
                 Expr::Infix(
-                    Box::new(Expr::from(2.0).into()),
+                    Box::new(Expr::from(2.0)),
                     String::from("+"),
-                    Box::new(Expr::from(2.0).into()),
+                    Box::new(Expr::from(2.0)),
                 )
                 .into(),
             ),

--- a/lib/src/semantics/analyze.rs
+++ b/lib/src/semantics/analyze.rs
@@ -1,5 +1,5 @@
 use super::{context::Context, util};
-use crate::ast::{Expr, Program, Stmt};
+use crate::ast::{Expr, Program, Stmt, Pattern};
 use crate::style::{bold, yellow};
 use std::default::Default;
 
@@ -33,9 +33,9 @@ pub fn analyze_stmt(stmt: Stmt, context: &mut Context) -> AnalysisResult {
         Stmt::Expr(expr) => analyze_expr(expr, context),
         Stmt::Assign(name, expr) => {
             let mut errors = vec![];
-            if let Expr::Array(array) = name {
+            if let Pattern::Array(array) = name {
                 for item in array {
-                    if let Expr::Ident(item) = item {
+                    if let Pattern::Ident(item) = item {
                         context.add(item.0, expr.clone());
                     } else {
                         errors.push(
@@ -43,9 +43,9 @@ pub fn analyze_stmt(stmt: Stmt, context: &mut Context) -> AnalysisResult {
                         )
                     }
                 }
-            } else if let Expr::Hash(hash) = name {
+            } else if let Pattern::Hash(hash) = name {
                 for (_key, value) in hash {
-                    if let Expr::Ident(value) = value {
+                    if let Pattern::Ident(value) = value {
                         context.add(value.0, expr.clone());
                     } else {
                         errors.push(
@@ -53,7 +53,7 @@ pub fn analyze_stmt(stmt: Stmt, context: &mut Context) -> AnalysisResult {
                         )
                     }
                 }
-            } else if let Expr::Ident(ident) = name {
+            } else if let Pattern::Ident(ident) = name {
                 context.add(ident.0, expr.clone());
             }
             let res = analyze_expr(expr, context);

--- a/lib/src/token.rs
+++ b/lib/src/token.rs
@@ -1,12 +1,12 @@
 use std::fmt;
 
-#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum Token {
     Illegal,
     EOF,
 
     Ident(String),  // foobar
-    Number(String), // Integer or float
+    Number(f64),    // Integer or float
     String(String), // "hello world"
     Symbol(String), // Self representing value, like :true
 
@@ -62,6 +62,7 @@ pub enum Token {
     If,
     Else,
     Then,
+    Let,
 }
 
 impl fmt::Display for Token {
@@ -139,6 +140,7 @@ pub fn lookup_keyword(name: &str) -> Token {
         "if" => Token::If,
         "then" => Token::Then,
         "else" => Token::Else,
+        "let" => Token::Let,
         _ => Token::Ident(name.to_string()),
     }
 }

--- a/src/file.rs
+++ b/src/file.rs
@@ -7,7 +7,7 @@ use std::rc::Rc;
 use lib::evaluation;
 use lib::lexer::Lexer;
 use lib::parser::Parser;
-use lib::semantics;
+// use lib::semantics;
 use lib::style;
 use path::Path;
 
@@ -26,17 +26,17 @@ pub fn exec_file(path: &Path) -> std::io::Result<()> {
             return Ok(());
         }
     };
-    let mut context = semantics::context::Context {
-        ..Default::default()
-    };
-    let analysis = semantics::analyze::analyze_stmts(program.clone(), Some(&mut context));
-    match analysis {
-        Err(errors) => {
-            handle_analysis_errors(errors);
-            return Ok(());
-        }
-        _ => {}
-    }
+    // let mut context = semantics::context::Context {
+    //     ..Default::default()
+    // };
+    // let analysis = semantics::analyze::analyze_stmts(program.clone(), Some(&mut context));
+    // match analysis {
+    //     Err(errors) => {
+    //         handle_analysis_errors(errors);
+    //         return Ok(());
+    //     }
+    //     _ => {}
+    // }
 
     let env = evaluation::env::Environment::new();
 

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -8,15 +8,15 @@ use std::rc::Rc;
 use lib::evaluation;
 use lib::lexer;
 use lib::parser::Parser;
-use lib::semantics;
+// use lib::semantics;
 use lib::style;
-use semantics::context::Context;
+// use semantics::context::Context;
 
 pub fn start() {
     let mut rl = Editor::<()>::new();
-    let mut context = Context {
-        ..Default::default()
-    };
+    // let mut context = Context {
+    //     ..Default::default()
+    // };
     let env = evaluation::env::Environment::new();
     let mut evaluator = evaluation::Evaluator::new(Rc::new(RefCell::new(env)));
     loop {
@@ -24,7 +24,7 @@ pub fn start() {
         match readline {
             Ok(line) => {
                 rl.add_history_entry(line.as_str());
-                eval(line.as_str(), &mut context, &mut evaluator)
+                eval(line.as_str() /* &mut context*/, &mut evaluator)
             }
             Err(ReadlineError::Interrupted) => {
                 println!("CTRL-C");
@@ -42,32 +42,32 @@ pub fn start() {
     }
 }
 
-fn eval(line: &str, context: &mut Context, eval: &mut Evaluator) {
+fn eval(line: &str, /*context: &mut Context,*/ eval: &mut Evaluator) {
     let l = lexer::Lexer::new(line);
     let mut p = Parser::new(l);
 
     let program = p.parse_program();
     if let Ok(program) = program {
-        let analysis = semantics::analyze::analyze_stmts(program.clone(), Some(context));
-        match analysis {
-            Ok(_) => {
-                let evaled = eval.eval_program(program);
-                if let Ok(evaled) = evaled {
-                    println!("{}", evaled);
-                } else if let Err(error) = evaled {
-                    println!("An error occurred while evaluating your code:\n{}", error);
-                }
-            }
-            Err(errors) => {
-                println!(
-                    "{}\nSorry to disturb you, but we had some trouble while analyzing your code for validity",
-                     style::bold("Semantic Analysis Errors:")
-                );
-                for error in errors {
-                    println!("{}\n", error);
-                }
-            }
+        // let analysis = semantics::analyze::analyze_stmts(program.clone(), Some(context));
+        // match Ok(true) {
+        // Ok(_) => {
+        let evaled = eval.eval_program(program);
+        if let Ok(evaled) = evaled {
+            println!("{}", evaled);
+        } else if let Err(error) = evaled {
+            println!("An error occurred while evaluating your code:\n{}", error);
         }
+        // }
+        //     Err(errors) => {
+        //         println!(
+        //             "{}\nSorry to disturb you, but we had some trouble while analyzing your code for validity",
+        //              style::bold("Semantic Analysis Errors:")
+        //         );
+        //         for error in errors {
+        //             println!("{}\n", error);
+        //         }
+        //     }
+        // }
     } else if let Err(error) = program {
         println!(
             "{}\nWe had a few problems while parsing your code",


### PR DESCRIPTION
I added support for proper pattern matching, along with some other changes:
- `let` required before a variable is declared
- Semantic analyzer disabled (will probably remove it at some point)

Other change I'd like to see in a different PR are:
- Proper errors types
- Better type representation (less allocations/perf stuff)