### PR TITLE
fix: Fix array and hash parsing

### DIFF
--- a/lib/src/lexer/lexer_test.rs
+++ b/lib/src/lexer/lexer_test.rs
@@ -90,7 +90,7 @@ fn test_numbers() {
         TokenType::Plus,
         TokenType::Number(4.5),
         TokenType::Asterisk,
-        TokenType::Number(8000.0)
+        TokenType::Number(8000.0),
     ];
     test_tokens(input, tests);
 }
@@ -98,7 +98,11 @@ fn test_numbers() {
 #[test]
 fn test_float_lookahead() {
     let input = "1..3";
-    let tests = vec![TokenType::Number(1.0), TokenType::Range, TokenType::Number(3.0)];
+    let tests = vec![
+        TokenType::Number(1.0),
+        TokenType::Range,
+        TokenType::Number(3.0),
+    ];
     test_tokens(input, tests)
 }
 

--- a/lib/src/parser/mod.rs
+++ b/lib/src/parser/mod.rs
@@ -1,10 +1,10 @@
+use crate::lexer::Lexer;
+use crate::token::{Token, TokenType};
+use crate::{ast, token::Position};
 use ast::{BlockStatement, Expr, Ident, Pattern, Program, Stmt};
 use error::{
     generate_parser_message, generate_pretty_error, ParserError, ParserResult, ParserType,
 };
-use crate::lexer::Lexer;
-use crate::token::{Token, TokenType};
-use crate::{ast, token::Position};
 
 mod error;
 
@@ -498,7 +498,6 @@ impl<'a> Parser<'a> {
         let mut items = vec![];
         if self.peek_token_is(&TokenType::RightBracket) {
             self.next_token();
-            self.next_token();
             return Ok(Expr::Array(items));
         }
 
@@ -521,7 +520,6 @@ impl<'a> Parser<'a> {
     fn parse_hash(&mut self) -> ParserResult<Expr> {
         let mut items = vec![];
         if self.peek_token_is(&TokenType::RightBrace) {
-            self.next_token();
             self.next_token();
             return Ok(Expr::Hash(items));
         }

--- a/lib/src/parser/parser_test.rs
+++ b/lib/src/parser/parser_test.rs
@@ -191,6 +191,18 @@ fn test_hash_expression() {
 }
 
 #[test]
+fn test_nested() {
+    let cases = vec![
+        ("[[]]", Expr::Array(vec![Expr::Array(vec![])]).into()),
+        (
+            "{ a = {} }",
+            Expr::Hash(vec![(Ident::from("a"), Expr::Hash(vec![]))]).into(),
+        ),
+    ];
+    test_multiple(cases)
+}
+
+#[test]
 fn test_call_expression() {
     let input = "foobar(a, b, c)";
     let expected = Expr::Call {
@@ -276,6 +288,12 @@ fn test_output(input: &str, expected: Vec<Stmt>) {
     } else if let Err(err) = program {
         println!("Parser had an error:\n{}", err);
         assert!(false);
+    }
+}
+
+fn test_multiple(cases: Vec<(&str, Vec<Stmt>)>) {
+    for (input, expected) in cases {
+        test_output(input, expected)
     }
 }
 

--- a/lib/src/token.rs
+++ b/lib/src/token.rs
@@ -37,7 +37,7 @@ impl fmt::Display for Position {
     }
 }
 
-#[derive(Debug, PartialEq, Clone,)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct Token {
     pub tok: TokenType,
     pub offset: usize,


### PR DESCRIPTION
Both were taking too many tokens, causing issues with empty arrays, or nested arrays

For example:
- `[[]]`
- `{}`
- `{ a = {} }`

Would all fail to parse properly