### PR TITLE
Implement index operator

### DIFF
--- a/lib/src/ast.rs
+++ b/lib/src/ast.rs
@@ -49,9 +49,10 @@ pub enum Expr {
     Ident(Ident),
     Prefix(String, Box<Expr>),
     Infix(Box<Expr>, String, Box<Expr>),
-    Index {
-        index: Box<Expr>,
-        of: Box<Expr>,
+    Member {
+        property: Box<Expr>,
+        object: Box<Expr>,
+        computed: bool,
     },
     Boolean(bool),
     String(String),
@@ -127,7 +128,17 @@ impl fmt::Display for Expr {
             Expr::Number(num) => write!(f, "{}", num),
             Expr::Prefix(op, expr) => write!(f, "({}{})", op, expr),
             Expr::Infix(left, operator, right) => write!(f, "({} {} {})", left, operator, right),
-            Expr::Index { index, of } => write!(f, "{}[{}]", of, index),
+            Expr::Member {
+                property: index,
+                object: of,
+                computed,
+            } => {
+                if *computed {
+                    write!(f, "{}[{}]", of, index)
+                } else {
+                    write!(f, "{}.({})", of, index)
+                }
+            }
             Expr::Boolean(value) => write!(f, "{}", value),
             Expr::String(value) => write!(f, "'{}'", value),
             Expr::Symbol(value) => write!(f, ":{}", value),

--- a/lib/src/ast.rs
+++ b/lib/src/ast.rs
@@ -49,6 +49,10 @@ pub enum Expr {
     Ident(Ident),
     Prefix(String, Box<Expr>),
     Infix(Box<Expr>, String, Box<Expr>),
+    Index {
+        index: Box<Expr>,
+        of: Box<Expr>,
+    },
     Boolean(bool),
     String(String),
     Symbol(String),
@@ -123,6 +127,7 @@ impl fmt::Display for Expr {
             Expr::Number(num) => write!(f, "{}", num),
             Expr::Prefix(op, expr) => write!(f, "({}{})", op, expr),
             Expr::Infix(left, operator, right) => write!(f, "({} {} {})", left, operator, right),
+            Expr::Index { index, of } => write!(f, "{}[{}]", of, index),
             Expr::Boolean(value) => write!(f, "{}", value),
             Expr::String(value) => write!(f, "'{}'", value),
             Expr::Symbol(value) => write!(f, ":{}", value),

--- a/lib/src/parser/parser_test.rs
+++ b/lib/src/parser/parser_test.rs
@@ -218,6 +218,25 @@ fn test_call_expression() {
 }
 
 #[test]
+fn test_index_expression() {
+    let input = "1..5[2] == 3";
+    let expected = Expr::Infix(
+        Box::new(Expr::Index {
+            index: Box::new(Expr::Number(2.0)),
+            of: Box::new(Expr::Infix(
+                Box::new(Expr::Number(1.0)),
+                String::from(".."),
+                Box::new(Expr::Number(5.0)),
+            )),
+        }),
+        "==".to_string(),
+        Box::new(Expr::Number(3.0)),
+    )
+    .into();
+    test_output(input, expected)
+}
+
+#[test]
 fn test_pattern() {
     let input = "[ 4.5, foo, true, :bar, 'hello', { abc, def }, _ ]";
     let expected = Pattern::Array(vec![

--- a/lib/src/parser/parser_test.rs
+++ b/lib/src/parser/parser_test.rs
@@ -219,18 +219,23 @@ fn test_call_expression() {
 
 #[test]
 fn test_index_expression() {
-    let input = "1..5[2] == 3";
+    let input = "1..5[2] == { a = 3 }.a";
     let expected = Expr::Infix(
-        Box::new(Expr::Index {
-            index: Box::new(Expr::Number(2.0)),
-            of: Box::new(Expr::Infix(
+        Box::new(Expr::Member {
+            property: Box::new(Expr::Number(2.0)),
+            object: Box::new(Expr::Infix(
                 Box::new(Expr::Number(1.0)),
                 String::from(".."),
                 Box::new(Expr::Number(5.0)),
             )),
+            computed: true,
         }),
         "==".to_string(),
-        Box::new(Expr::Number(3.0)),
+        Box::new(Expr::Member {
+            property: Expr::Ident(Ident::from("a")).into(),
+            object: Expr::Hash(vec![(Ident::from("a"), Expr::Number(3.0))]).into(),
+            computed: false,
+        }),
     )
     .into();
     test_output(input, expected)


### PR DESCRIPTION
This PR adds a index/member operator. The syntax is as follows:

```bliss
0..5[3] // Calculated indexing
{ a = 5 }["a"] // Calculated indexing
{ a = 5 }.a // Not calculated
```

This basically just follows the JavaScript notation, as it's the form I use most.

Later on, I might also add the ability to do something like `[0, 1, 2].(1)` as an alternative form.